### PR TITLE
Feat 60 oauth login

### DIFF
--- a/.github/workflows/moongch-test.yml
+++ b/.github/workflows/moongch-test.yml
@@ -6,7 +6,7 @@ on:
     paths-ignore:
       - '.github/**'
       - 'docs/readme.md'
-    types: [ opened, synchronize, reopened ] # PR의 상태 변경 이벤트
+    types: [ opened, synchronize ] # PR의 상태 변경 이벤트
 
 jobs:
   unit-test:

--- a/src/main/java/com/devsco/moongch/common/config/RestTemplateConfig.java
+++ b/src/main/java/com/devsco/moongch/common/config/RestTemplateConfig.java
@@ -1,0 +1,15 @@
+package com.devsco.moongch.common.config;
+
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class RestTemplateConfig {
+
+  @Bean
+  public RestTemplate restTemplate(RestTemplateBuilder  builder) {
+    return builder.build();
+  }
+}

--- a/src/main/java/com/devsco/moongch/common/config/SecurityConfig.java
+++ b/src/main/java/com/devsco/moongch/common/config/SecurityConfig.java
@@ -40,7 +40,7 @@ public class SecurityConfig {
       .formLogin(AbstractHttpConfigurer::disable)
       .logout(logout -> logout.logoutUrl("/perform_logout"))
       .authorizeHttpRequests(auth -> auth
-        .requestMatchers("/oauth2/authorization/**", "/login/oauth2/**","/logout").permitAll()
+        .requestMatchers("/oauth2/authorization/**", "/login/oauth2/**", "/logout").permitAll()
         .anyRequest().authenticated()
       )
       .oauth2Login(oauth2 -> oauth2

--- a/src/main/java/com/devsco/moongch/common/oauth/AuthController.java
+++ b/src/main/java/com/devsco/moongch/common/oauth/AuthController.java
@@ -13,7 +13,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class AuthController {
 
   @PostMapping("/logout")
-  public ResponseEntity<?> logout(HttpServletRequest request,HttpServletResponse response) {
+  public ResponseEntity<?> logout(HttpServletRequest request, HttpServletResponse response) {
     CookieUtils.deleteCookie(request, response, "JWT_TOKEN");
     return ResponseEntity.ok("로그아웃 되었습니다.");
   }

--- a/src/main/java/com/devsco/moongch/common/oauth/CustomOAuth2Service.java
+++ b/src/main/java/com/devsco/moongch/common/oauth/CustomOAuth2Service.java
@@ -1,5 +1,7 @@
 package com.devsco.moongch.common.oauth;
 
+import com.devsco.moongch.oauth.OAuth2UserInfo;
+import com.devsco.moongch.oauth.OAuth2UserInfoFactory;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.core.ParameterizedTypeReference;
@@ -24,34 +26,34 @@ import java.util.Map;
 @RequiredArgsConstructor
 public class CustomOAuth2Service extends DefaultOAuth2UserService {
 
-  private final OAuth2UserInfoFactory oAuth2UserInfoFactory;
+  private final OAuth2UserInfoFactory oauth2UserInfoFactory;
   private final RestTemplate restTemplate;
 
   @Override
-  public OAuth2User loadUser(OAuth2UserRequest oAuth2UserRequest) throws OAuth2AuthenticationException {
-    OAuth2User oAuth2User = super.loadUser(oAuth2UserRequest);
-    String registrationId = oAuth2UserRequest.getClientRegistration().getRegistrationId();
-    log.info("OAuth2 userInfo from {}: {}", registrationId, oAuth2User.getAttributes());
+  public OAuth2User loadUser(OAuth2UserRequest outh2UserRequest) throws OAuth2AuthenticationException {
+    OAuth2User oauth2User = super.loadUser(outh2UserRequest);
+    String registrationId = outh2UserRequest.getClientRegistration().getRegistrationId();
+    log.info("OAuth2 userInfo from {}: {}", registrationId, oauth2User.getAttributes());
 
     OAuth2UserInfo userInfo =
-      oAuth2UserInfoFactory.getOAuth2UserInfo(registrationId, oAuth2User.getAttributes());
+      oauth2UserInfoFactory.getOAuth2UserInfo(registrationId, oauth2User.getAttributes());
 
-    Map<String, Object> attributes = new HashMap<>(oAuth2User.getAttributes());
+    Map<String, Object> attributes = new HashMap<>(oauth2User.getAttributes());
     if ("github".equals(registrationId)) {
-      String accessToken = oAuth2UserRequest.getAccessToken().getTokenValue();
+      String accessToken = outh2UserRequest.getAccessToken().getTokenValue();
       String email = fetchGithubPrimaryEmail(accessToken);
       attributes.put("email", email);
     } else {
       attributes.put("email", userInfo.getEmail());
     }
 
-    String userNameAttr = oAuth2UserRequest.getClientRegistration()
+    String userNameAttr = outh2UserRequest.getClientRegistration()
       .getProviderDetails()
       .getUserInfoEndpoint()
       .getUserNameAttributeName();
 
     return new DefaultOAuth2User(
-      oAuth2User.getAuthorities(),
+      oauth2User.getAuthorities(),
       attributes,
       userNameAttr
     );

--- a/src/main/java/com/devsco/moongch/common/oauth/CustomOAuth2Service.java
+++ b/src/main/java/com/devsco/moongch/common/oauth/CustomOAuth2Service.java
@@ -1,5 +1,6 @@
 package com.devsco.moongch.common.oauth;
 
+import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
@@ -13,7 +14,10 @@ import java.util.Map;
 
 @Service
 @Log4j2
+@RequiredArgsConstructor
 public class CustomOAuth2Service extends DefaultOAuth2UserService {
+
+  private final OAuth2UserInfoFactory oAuth2UserInfoFactory;
 
   @Override
   public OAuth2User loadUser(OAuth2UserRequest oAuth2UserRequest) throws OAuth2AuthenticationException {
@@ -21,7 +25,7 @@ public class CustomOAuth2Service extends DefaultOAuth2UserService {
     String registrationId = oAuth2UserRequest.getClientRegistration().getRegistrationId();
     log.info("OAuth2 userInfo from {}: {}", registrationId, oAuth2User.getAttributes());
 
-    OAuth2UserInfo userInfo = OAuth2UserInfoFactory.getOAuth2UserInfo(registrationId, oAuth2User.getAttributes());
+    OAuth2UserInfo userInfo = oAuth2UserInfoFactory.getOAuth2UserInfo(registrationId, oAuth2User.getAttributes());
 
     Map<String, Object> attributes = new HashMap<>(userInfo.getAttributes());
     attributes.put("email", userInfo.getEmail());

--- a/src/main/java/com/devsco/moongch/common/oauth/CustomOAuth2Service.java
+++ b/src/main/java/com/devsco/moongch/common/oauth/CustomOAuth2Service.java
@@ -2,14 +2,21 @@ package com.devsco.moongch.common.oauth;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
 import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
 import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 @Service
@@ -18,6 +25,7 @@ import java.util.Map;
 public class CustomOAuth2Service extends DefaultOAuth2UserService {
 
   private final OAuth2UserInfoFactory oAuth2UserInfoFactory;
+  private final RestTemplate restTemplate;
 
   @Override
   public OAuth2User loadUser(OAuth2UserRequest oAuth2UserRequest) throws OAuth2AuthenticationException {
@@ -25,11 +33,56 @@ public class CustomOAuth2Service extends DefaultOAuth2UserService {
     String registrationId = oAuth2UserRequest.getClientRegistration().getRegistrationId();
     log.info("OAuth2 userInfo from {}: {}", registrationId, oAuth2User.getAttributes());
 
-    OAuth2UserInfo userInfo = oAuth2UserInfoFactory.getOAuth2UserInfo(registrationId, oAuth2User.getAttributes());
+    OAuth2UserInfo userInfo =
+      oAuth2UserInfoFactory.getOAuth2UserInfo(registrationId, oAuth2User.getAttributes());
 
-    Map<String, Object> attributes = new HashMap<>(userInfo.getAttributes());
-    attributes.put("email", userInfo.getEmail());
+    Map<String, Object> attributes = new HashMap<>(oAuth2User.getAttributes());
+    if ("github".equals(registrationId)) {
+      String accessToken = oAuth2UserRequest.getAccessToken().getTokenValue();
+      String email = fetchGithubPrimaryEmail(accessToken);
+      attributes.put("email", email);
+    } else {
+      attributes.put("email", userInfo.getEmail());
+    }
 
-    return new DefaultOAuth2User(oAuth2User.getAuthorities(), attributes, "id");
+    String userNameAttr = oAuth2UserRequest.getClientRegistration()
+      .getProviderDetails()
+      .getUserInfoEndpoint()
+      .getUserNameAttributeName();
+
+    return new DefaultOAuth2User(
+      oAuth2User.getAuthorities(),
+      attributes,
+      userNameAttr
+    );
+  }
+
+  /**
+   * GitHub의 /user/emails 엔드포인트를 호출하여
+   * primary & verified 이메일을 찾아 반환합니다.
+   */
+  private String fetchGithubPrimaryEmail(String accessToken) {
+    HttpHeaders headers = new HttpHeaders();
+    headers.setBearerAuth(accessToken);
+    HttpEntity<Void> entity = new HttpEntity<>(headers);
+
+    ResponseEntity<List<Map<String, Object>>> response = restTemplate.exchange(
+      "https://api.github.com/user/emails",
+      HttpMethod.GET,
+      entity,
+      new ParameterizedTypeReference<>() {
+      }
+    );
+
+    if (!response.getStatusCode().is2xxSuccessful() || response.getBody() == null) {
+      return null;
+    }
+
+    return response.getBody().stream()
+      .filter(e -> Boolean.TRUE.equals(e.get("primary"))
+        && Boolean.TRUE.equals(e.get("verified")))
+      .map(e -> (String) e.get("email"))
+      .findFirst()
+      .orElse(null);
   }
 }

--- a/src/main/java/com/devsco/moongch/common/oauth/CustomOAuth2Service.java
+++ b/src/main/java/com/devsco/moongch/common/oauth/CustomOAuth2Service.java
@@ -4,8 +4,12 @@ import lombok.extern.log4j.Log4j2;
 import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
 import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.stereotype.Service;
+
+import java.util.HashMap;
+import java.util.Map;
 
 @Service
 @Log4j2
@@ -13,11 +17,15 @@ public class CustomOAuth2Service extends DefaultOAuth2UserService {
 
   @Override
   public OAuth2User loadUser(OAuth2UserRequest oAuth2UserRequest) throws OAuth2AuthenticationException {
-    // 기본 사용자 정보 불러오기
     OAuth2User oAuth2User = super.loadUser(oAuth2UserRequest);
+    String registrationId = oAuth2UserRequest.getClientRegistration().getRegistrationId();
+    log.info("OAuth2 userInfo from {}: {}", registrationId, oAuth2User.getAttributes());
 
-    log.info("OAuth2 userInfo : {}", oAuth2User.getAttributes());
+    OAuth2UserInfo userInfo = OAuth2UserInfoFactory.getOAuth2UserInfo(registrationId, oAuth2User.getAttributes());
 
-    return oAuth2User;
+    Map<String, Object> attributes = new HashMap<>(userInfo.getAttributes());
+    attributes.put("email", userInfo.getEmail());
+
+    return new DefaultOAuth2User(oAuth2User.getAuthorities(), attributes, "id");
   }
 }

--- a/src/main/java/com/devsco/moongch/common/oauth/GoogleOAuth2UserInfoParser.java
+++ b/src/main/java/com/devsco/moongch/common/oauth/GoogleOAuth2UserInfoParser.java
@@ -12,12 +12,14 @@ public class GoogleOAuth2UserInfoParser implements OAuth2UserInfoParser {
     return new OAuth2UserInfo() {
       @Override
       public String getEmail() {
-        return attributes.get("email").toString();
+        Object email = attributes.get("email");
+        return email != null ? email.toString() : null;
       }
 
       @Override
       public String getId() {
-        return attributes.get("sub").toString();
+        Object id = attributes.get("sub");
+        return id != null ? id.toString() : null;
       }
 
       @Override

--- a/src/main/java/com/devsco/moongch/common/oauth/GoogleOAuth2UserInfoParser.java
+++ b/src/main/java/com/devsco/moongch/common/oauth/GoogleOAuth2UserInfoParser.java
@@ -1,0 +1,30 @@
+package com.devsco.moongch.oauth;
+
+import org.springframework.stereotype.Component;
+
+import java.util.Map;
+
+@Component("google")
+public class GoogleOAuth2UserInfoParser implements OAuth2UserInfoParser {
+
+  @Override
+  public OAuth2UserInfo parse(Map<String, Object> attributes) {
+    return new OAuth2UserInfo() {
+      @Override
+      public String getEmail() {
+        return (String) attributes.get("email");
+      }
+
+      @Override
+      public String getId() {
+        return (String) attributes.get("sub");
+      }
+
+      @Override
+      public Map<String, Object> getAttributes() {
+        return attributes;
+      }
+    };
+  }
+}
+

--- a/src/main/java/com/devsco/moongch/common/oauth/JwtAuthenticationException.java
+++ b/src/main/java/com/devsco/moongch/common/oauth/JwtAuthenticationException.java
@@ -3,8 +3,8 @@ package com.devsco.moongch.common.oauth;
 import org.springframework.security.core.AuthenticationException;
 
 public class JwtAuthenticationException extends AuthenticationException {
-  public JwtAuthenticationException(Throwable cause){
-    super(generateMessage(cause),cause);
+  public JwtAuthenticationException(Throwable cause) {
+    super(generateMessage(cause), cause);
   }
 
   private static String generateMessage(Throwable cause) {

--- a/src/main/java/com/devsco/moongch/common/oauth/JwtAuthenticationFilter.java
+++ b/src/main/java/com/devsco/moongch/common/oauth/JwtAuthenticationFilter.java
@@ -13,7 +13,9 @@ import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
-import java.util.*;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 
 @Log4j2
 @RequiredArgsConstructor

--- a/src/main/java/com/devsco/moongch/common/oauth/JwtProvider.java
+++ b/src/main/java/com/devsco/moongch/common/oauth/JwtProvider.java
@@ -1,8 +1,14 @@
 package com.devsco.moongch.common.oauth;
 
-import io.jsonwebtoken.*;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.UnsupportedJwtException;
 import io.jsonwebtoken.io.Decoders;
 import io.jsonwebtoken.security.Keys;
+import io.jsonwebtoken.security.SignatureException;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
@@ -48,7 +54,8 @@ public class JwtProvider {
   }
 
   /**
-   * JWT 유효성 검사 메서드
+   * JWT 유효성 검사 메서드.
+   *
    * @param token 검증할 JWT 토큰
    * @return JwtCode.ACCESS 토큰이 유효할 때, JwtCode.EXPIRED 토큰 만료, 그 외 DENIED 반환
    */
@@ -59,14 +66,15 @@ public class JwtProvider {
         .build()
         .parseClaimsJws(token);
       return JwtCode.ACCESS;
-    } catch (ExpiredJwtException | UnsupportedJwtException | MalformedJwtException | SignatureException | IllegalArgumentException e) {
+    } catch (ExpiredJwtException | UnsupportedJwtException | MalformedJwtException | SignatureException
+      | IllegalArgumentException e) {
       throw new JwtAuthenticationException(e);
     }
   }
 
   public String extractJwtToken(HttpServletRequest request) {
     return Optional.ofNullable(request.getHeader(jwtProperties.header()))
-      .filter(auth -> auth.startsWith(jwtProperties.prefix()+" "))
+      .filter(auth -> auth.startsWith(jwtProperties.prefix() + " "))
       .map(auth -> auth.substring(7))
       .orElseGet(() -> getCookieValue(request));
   }

--- a/src/main/java/com/devsco/moongch/common/oauth/KakaoOAuth2UserInfoParser.java
+++ b/src/main/java/com/devsco/moongch/common/oauth/KakaoOAuth2UserInfoParser.java
@@ -1,0 +1,31 @@
+package com.devsco.moongch.oauth;
+
+import org.springframework.stereotype.Component;
+
+import java.util.Map;
+
+@Component("kakao")
+public class KakaoOAuth2UserInfoParser implements OAuth2UserInfoParser {
+
+
+  @Override
+  public OAuth2UserInfo parse(Map<String, Object> attributes) {
+    return new OAuth2UserInfo() {
+      @Override
+      public String getEmail() {
+        Map<String, Object> kakaoAccount = (Map<String, Object>) attributes.get("kakao_account");
+        return kakaoAccount != null ? (String) kakaoAccount.get("email") : null;
+      }
+
+      @Override
+      public String getId() {
+        return attributes.get("id") != null ? (String) attributes.get("id") : null;
+      }
+
+      @Override
+      public Map<String, Object> getAttributes() {
+        return attributes;
+      }
+    };
+  }
+}

--- a/src/main/java/com/devsco/moongch/common/oauth/KakaoOAuth2UserInfoParser.java
+++ b/src/main/java/com/devsco/moongch/common/oauth/KakaoOAuth2UserInfoParser.java
@@ -14,12 +14,12 @@ public class KakaoOAuth2UserInfoParser implements OAuth2UserInfoParser {
       @Override
       public String getEmail() {
         Map<String, Object> kakaoAccount = (Map<String, Object>) attributes.get("kakao_account");
-        return kakaoAccount != null ? (String) kakaoAccount.get("email") : null;
+        return kakaoAccount != null ? kakaoAccount.get("email").toString() : null;
       }
 
       @Override
       public String getId() {
-        return attributes.get("id") != null ? (String) attributes.get("id") : null;
+        return attributes.get("id") != null ? attributes.get("id").toString() : null;
       }
 
       @Override

--- a/src/main/java/com/devsco/moongch/common/oauth/OAuth2UserInfo.java
+++ b/src/main/java/com/devsco/moongch/common/oauth/OAuth2UserInfo.java
@@ -1,9 +1,9 @@
-package com.devsco.moongch.oauth;
+  package com.devsco.moongch.oauth;
 
-import java.util.Map;
+  import java.util.Map;
 
-public interface OAuth2UserInfo {
-  String getEmail();
-  String getId();
-  Map<String, Object> getAttributes();
-}
+  public interface OAuth2UserInfo {
+    String getEmail();
+    String getId();
+    Map<String, Object> getAttributes();
+  }

--- a/src/main/java/com/devsco/moongch/common/oauth/OAuth2UserInfo.java
+++ b/src/main/java/com/devsco/moongch/common/oauth/OAuth2UserInfo.java
@@ -1,9 +1,11 @@
-  package com.devsco.moongch.oauth;
+package com.devsco.moongch.common.oauth;
 
-  import java.util.Map;
+import java.util.Map;
 
-  public interface OAuth2UserInfo {
-    String getEmail();
-    String getId();
-    Map<String, Object> getAttributes();
-  }
+public interface OAuth2UserInfo {
+  String getEmail();
+
+  String getId();
+
+  Map<String, Object> getAttributes();
+}

--- a/src/main/java/com/devsco/moongch/common/oauth/OAuth2UserInfo.java
+++ b/src/main/java/com/devsco/moongch/common/oauth/OAuth2UserInfo.java
@@ -1,0 +1,9 @@
+package com.devsco.moongch.oauth;
+
+import java.util.Map;
+
+public interface OAuth2UserInfo {
+  String getEmail();
+  String getId();
+  Map<String, Object> getAttributes();
+}

--- a/src/main/java/com/devsco/moongch/common/oauth/OAuth2UserInfoParser.java
+++ b/src/main/java/com/devsco/moongch/common/oauth/OAuth2UserInfoParser.java
@@ -1,0 +1,7 @@
+package com.devsco.moongch.oauth;
+
+import java.util.Map;
+
+public interface OAuth2UserInfoParser {
+  OAuth2UserInfo parse(Map<String, Object> attributes);
+}

--- a/src/main/java/com/devsco/moongch/infrastructure/MoongchEntity.java
+++ b/src/main/java/com/devsco/moongch/infrastructure/MoongchEntity.java
@@ -17,7 +17,7 @@ import lombok.NoArgsConstructor;
 @Table(schema = "moongch", name = "moongch")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@AllArgsConstructor(access =AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Builder
 public class MoongchEntity {
   @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/devsco/moongch/infrastructure/MoongchLikesEntity.java
+++ b/src/main/java/com/devsco/moongch/infrastructure/MoongchLikesEntity.java
@@ -15,7 +15,7 @@ import lombok.NoArgsConstructor;
 @Table(schema = "moongch", name = "moongch_likes")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@AllArgsConstructor(access =AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Builder
 public class MoongchLikesEntity {
 

--- a/src/main/java/com/devsco/moongch/infrastructure/MoongchTagEntity.java
+++ b/src/main/java/com/devsco/moongch/infrastructure/MoongchTagEntity.java
@@ -15,7 +15,7 @@ import lombok.NoArgsConstructor;
 @Table(schema = "moongch", name = "moongch_tag")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@AllArgsConstructor(access =AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Builder
 public class MoongchTagEntity {
   @Id @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/devsco/moongch/infrastructure/TagEntity.java
+++ b/src/main/java/com/devsco/moongch/infrastructure/TagEntity.java
@@ -15,7 +15,7 @@ import lombok.NoArgsConstructor;
 @Table(schema = "moongch", name = "tag")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@AllArgsConstructor(access =AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Builder
 public class TagEntity {
   @Id @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/devsco/moongch/oauth/GitHubOauth2UserInfoParser.java
+++ b/src/main/java/com/devsco/moongch/oauth/GitHubOauth2UserInfoParser.java
@@ -12,13 +12,14 @@ public class GitHubOauth2UserInfoParser implements OAuth2UserInfoParser {
     return new OAuth2UserInfo() {
       @Override
       public String getEmail() {
-        Object email = attributes.get("name");
+        Object email = attributes.get("email");
         return email != null ? email.toString() : null;
       }
 
       @Override
       public String getId() {
-        return attributes.get("id").toString();
+        Object id = attributes.get("id");
+        return id != null ? id.toString() : null;
       }
 
       @Override

--- a/src/main/java/com/devsco/moongch/oauth/GitHubOauth2UserInfoParser.java
+++ b/src/main/java/com/devsco/moongch/oauth/GitHubOauth2UserInfoParser.java
@@ -4,20 +4,21 @@ import org.springframework.stereotype.Component;
 
 import java.util.Map;
 
-@Component("google")
-public class GoogleOAuth2UserInfoParser implements OAuth2UserInfoParser {
+@Component("github")
+public class GitHubOauth2UserInfoParser implements OAuth2UserInfoParser {
 
   @Override
   public OAuth2UserInfo parse(Map<String, Object> attributes) {
     return new OAuth2UserInfo() {
       @Override
       public String getEmail() {
-        return attributes.get("email").toString();
+        Object email = attributes.get("name");
+        return email != null ? email.toString() : null;
       }
 
       @Override
       public String getId() {
-        return attributes.get("sub").toString();
+        return attributes.get("id").toString();
       }
 
       @Override
@@ -27,4 +28,3 @@ public class GoogleOAuth2UserInfoParser implements OAuth2UserInfoParser {
     };
   }
 }
-

--- a/src/main/java/com/devsco/moongch/oauth/OAuth2UserInfoFactory.java
+++ b/src/main/java/com/devsco/moongch/oauth/OAuth2UserInfoFactory.java
@@ -1,0 +1,25 @@
+package com.devsco.moongch.oauth;
+
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.stereotype.Component;
+
+import java.util.Map;
+
+@Component
+@Log4j2
+@RequiredArgsConstructor
+public class OAuth2UserInfoFactory {
+  private final Map<String, OAuth2UserInfoParser> parserMap;
+
+  public OAuth2UserInfo getOAuth2UserInfo(String registrationId, Map<String, Object> attributes) {
+    OAuth2UserInfoParser parser = parserMap.get(registrationId.toLowerCase());
+    log.info("registrationId: {},  parserMap.get : {}", registrationId, parserMap.get(registrationId));
+
+    if (parser == null) {
+      throw new UnsupportedOperationException("지원하지 않는 로그인 방식입니다. " + registrationId);
+    }
+    return parser.parse(attributes);
+  }
+}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -50,6 +50,8 @@ logging:
     org:
       springframework:
         web: DEBUG
+  file:
+    name: logs/app-dev.log
 
 jwt:
   secret: ${JWT_SECRET}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -13,6 +13,11 @@ spring:
             client-secret: ${GOOGLE_CLIENT_SECRET}
             scope: openid, profile, email # openid 추가시 OIDC 플로우
             redirect-uri: "http://localhost:8080/login/oauth2/code/google"
+          github:
+            client-id: ${GITHUB_CLIENT_ID}
+            client-secret: ${GITHUB_CLIENT_SECRET}
+            scope: read:user, user:email
+            redirect-uri: "http://localhost:8080/login/oauth2/code/github"
           kakao:
             client-id: ${KAKAO_CLIENT_ID}
             scope: profile_nickname, profile_image, account_email

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -13,6 +13,18 @@ spring:
             client-secret: ${GOOGLE_CLIENT_SECRET}
             scope: openid, profile, email # openid 추가시 OIDC 플로우
             redirect-uri: "http://localhost:8080/login/oauth2/code/google"
+          kakao:
+            client-id: ${KAKAO_CLIENT_ID}
+            scope: profile_nickname, profile_image, account_email
+            authorization-grant-type: authorization_code
+            redirect-uri: "http://localhost:8080/login/oauth2/code/kakao"
+            provider: kakao
+        provider:
+          kakao:
+            authorization-uri: https://kauth.kakao.com/oauth/authorize
+            token-uri: https://kauth.kakao.com/oauth/token
+            user-info-uri: https://kapi.kakao.com/v2/user/me
+            user-name-attribute: id
 
   datasource:
     driver-class-name: org.postgresql.Driver

--- a/src/test/java/com/devsco/moongch/oauth/AuthControllerTest.java
+++ b/src/test/java/com/devsco/moongch/oauth/AuthControllerTest.java
@@ -1,0 +1,77 @@
+package com.devsco.moongch.oauth;
+
+import com.devsco.moongch.oauth.utill.CookieUtils;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(AuthController.class)
+@AutoConfigureMockMvc(addFilters = false) // 순수 컨트롤러 테스트를 위함
+public class AuthControllerTest {
+
+  @Autowired
+  private MockMvc mockMvc;
+
+  @Test
+  @WithMockUser
+  @DisplayName("로그아웃 요청시 JWT 토큰 쿠키가 삭제되고 성공 메시지가 반환되는지 확인")
+  void testLogout() throws Exception {
+    try (MockedStatic<CookieUtils> cookieUtilsMock = Mockito.mockStatic(CookieUtils.class)) {
+      cookieUtilsMock.when(() -> CookieUtils.deleteCookie(any(HttpServletRequest.class),
+          any(HttpServletResponse.class),
+          eq("JWT_TOKEN")))
+        .thenAnswer(invocation -> null);
+
+      ResultActions resultActions = mockMvc.perform(post("/logout")
+        .cookie(new Cookie("JWT_TOKEN", "test-token-value"))
+        .with(SecurityMockMvcRequestPostProcessors.csrf()));
+
+      resultActions
+        .andExpect(status().isOk())
+        .andExpect(content().string("로그아웃 되었습니다."));
+
+      cookieUtilsMock.verify(() -> CookieUtils.deleteCookie(any(HttpServletRequest.class),
+        any(HttpServletResponse.class),
+        eq("JWT_TOKEN")));
+    }
+  }
+
+  @Test
+  @WithMockUser
+  void testLogoutWithoutCookie() throws Exception {
+    try (MockedStatic<CookieUtils> cookieUtilsMock = Mockito.mockStatic(CookieUtils.class)) {
+      cookieUtilsMock.when(() -> CookieUtils.deleteCookie(any(HttpServletRequest.class),
+          any(HttpServletResponse.class),
+          eq("JWT_TOKEN")))
+        .thenAnswer(invocation -> null);
+
+      ResultActions resultActions = mockMvc.perform(post("/logout")
+        .with(SecurityMockMvcRequestPostProcessors.csrf()));
+
+      resultActions
+        .andExpect(status().isOk())
+        .andExpect(content().string("로그아웃 되었습니다."));
+
+      cookieUtilsMock.verify(() -> CookieUtils.deleteCookie(any(HttpServletRequest.class),
+        any(HttpServletResponse.class),
+        eq("JWT_TOKEN")));
+    }
+  }
+}

--- a/src/test/java/com/devsco/moongch/oauth/GitHubOauth2UserInfoParserTest.java
+++ b/src/test/java/com/devsco/moongch/oauth/GitHubOauth2UserInfoParserTest.java
@@ -1,0 +1,45 @@
+package com.devsco.moongch.oauth;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class GitHubOauth2UserInfoParserTest {
+
+  private final GitHubOauth2UserInfoParser parser = new GitHubOauth2UserInfoParser();
+
+  @Test
+  @DisplayName("정상적인 attributes 맵 입력 시 OAuth2UserInfo의 getEmail, getId, getAttributes가 예상대로 동작하는지 검증")
+  void parse_returnsCorrectUserInfo() {
+    // given
+    Map<String, Object> attributes = Map.of(
+      "id", 42,
+      "email", "test@github.com"
+    );
+
+    // when
+    OAuth2UserInfo userInfo = parser.parse(attributes);
+
+    // then
+    assertThat(userInfo.getId()).isEqualTo("42");
+    assertThat(userInfo.getEmail()).isEqualTo("test@github.com");
+    assertThat(userInfo.getAttributes()).isSameAs(attributes);
+  }
+
+  @Test
+  @DisplayName("email 필드가 없을 경우 getEmail은 null을 반환하는지 확인")
+  void parse_whenNameMissing_thenEmailIsNull() {
+    // given
+    Map<String, Object> attributes = Map.of("id", 99);
+
+    // when
+    OAuth2UserInfo userInfo = parser.parse(attributes);
+
+    // then
+    assertThat(userInfo.getEmail()).isNull();
+  }
+
+}

--- a/src/test/java/com/devsco/moongch/oauth/GoogleOAuth2UserInfoParserTest.java
+++ b/src/test/java/com/devsco/moongch/oauth/GoogleOAuth2UserInfoParserTest.java
@@ -1,0 +1,47 @@
+package com.devsco.moongch.oauth;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+
+class GoogleOAuth2UserInfoParserTest {
+
+  private final GoogleOAuth2UserInfoParser parser = new GoogleOAuth2UserInfoParser();
+
+
+  @Test
+  @DisplayName("정상적인 attributes 맵 입력 시 OAuth2UserInfo의 getEmail, getId, getAttributes가 예상대로 동작하는지 검증")
+  void parse_returnsCorrectUserInfo() {
+    // given
+    Map<String, Object> attributes = Map.of(
+      "sub", "13",
+      "email", "test@example.com"
+    );
+
+    // when
+    OAuth2UserInfo userInfo = parser.parse(attributes);
+
+    // then
+    assertThat(userInfo.getId()).isEqualTo("13");
+    assertThat(userInfo.getEmail()).isEqualTo("test@example.com");
+    assertThat(userInfo.getAttributes()).isSameAs(attributes);
+  }
+
+
+  @Test
+  @DisplayName("email 필드가 없을 경우 getEmail은 null을 반환하는지 확인")
+  public void test() throws Exception{
+    // given
+    Map<String, Object> attributes = Map.of("id", 99);
+
+    // when
+    OAuth2UserInfo userInfo = parser.parse(attributes);
+
+    // then
+    assertThat(userInfo.getEmail()).isNull();
+  }
+}

--- a/src/test/java/com/devsco/moongch/oauth/KakaoOAuth2UserInfoParserTest.java
+++ b/src/test/java/com/devsco/moongch/oauth/KakaoOAuth2UserInfoParserTest.java
@@ -1,0 +1,49 @@
+package com.devsco.moongch.oauth;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class KakaoOAuth2UserInfoParserTest {
+
+  private final KakaoOAuth2UserInfoParser parser = new KakaoOAuth2UserInfoParser();
+
+  @Test
+  @DisplayName("정상적인 attributes 맵 입력 시 OAuth2UserInfo의 getEmail, getId, getAttributes가 예상대로 동작하는지 검증")
+  void parse_returnsCorrectUserInfo() {
+    // given
+    Map<String, Object> kakaoAccount = Map.of(
+      "email", "test@kakao.com"
+    );
+    Map<String, Object> attributes = Map.of(
+      "id", 12345,
+      "kakao_account", kakaoAccount
+    );
+
+    // when
+    OAuth2UserInfo userInfo = parser.parse(attributes);
+
+    // then
+    assertThat(userInfo.getId()).isEqualTo("12345");
+    assertThat(userInfo.getEmail()).isEqualTo("test@kakao.com");
+    assertThat(userInfo.getAttributes()).isSameAs(attributes);
+  }
+
+
+  @Test
+  @DisplayName("email 필드가 없을 경우 null을 반환하는지 확인")
+  void parse_withNullEmail_thenReturnsNull() {
+    // given
+    Map<String, Object> attributes = Map.of("id", 12345);
+
+    // when
+    OAuth2UserInfo userInfo = parser.parse(attributes);
+
+    // then
+    assertThat(userInfo.getEmail()).isNull();
+
+  }
+}

--- a/src/test/java/com/devsco/moongch/oauth/OAuth2UserInfoFactoryTest.java
+++ b/src/test/java/com/devsco/moongch/oauth/OAuth2UserInfoFactoryTest.java
@@ -1,0 +1,87 @@
+package com.devsco.moongch.oauth;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class OAuth2UserInfoFactoryTest {
+
+  @Mock
+  private OAuth2UserInfoParser kakaoParser;
+
+  @Mock
+  private OAuth2UserInfoParser googleParser;
+
+  private OAuth2UserInfoFactory factory;
+
+
+  @BeforeEach
+  void setUp() {
+    Map<String, OAuth2UserInfoParser> parserMap = Map.of(
+      "kakao", kakaoParser,
+      "google", googleParser
+    );
+    factory = new OAuth2UserInfoFactory(parserMap);
+  }
+
+
+
+  @Test
+  @DisplayName("알려진 registrationId로 요청하면 해당 파서를 통해 정상적으로 OAuth2UserInfo를 반환하는지 확인")
+  void whenKnownRegistration_thenReturnsParsedInfo() {
+    Map<String, Object> attributes = Map.of("id", "123", "name", "Tester");
+    OAuth2UserInfo expectedUserInfo = mock(OAuth2UserInfo.class);
+
+    given(kakaoParser.parse(attributes)).willReturn(expectedUserInfo);
+
+    OAuth2UserInfo actual = factory.getOAuth2UserInfo("kakao", attributes);
+
+    assertThat(actual).isSameAs(expectedUserInfo);
+  }
+
+
+
+
+  @Test
+  @DisplayName("대소문자 구분 없이 registrationId로 파서가 매핑되는지 확인")
+  void whenRegistrationIdCaseMismatch_thenStillMatchesParser() {
+    // given
+    Map<String, Object> attrs = Map.of("id", "abc");
+    OAuth2UserInfo dummyInfo = mock(OAuth2UserInfo.class);
+
+    given(googleParser.parse(attrs)).willReturn(dummyInfo);
+
+    // when
+    OAuth2UserInfo result = factory.getOAuth2UserInfo("GOOGLE", attrs);
+
+    // then
+    assertThat(result).isSameAs(dummyInfo);
+  }
+
+
+
+  @Test
+  @DisplayName("지원하지 않는 registrationId로 요청 시 UnsupportedOperationException 발생하는지 확인")
+  void whenUnknownRegistration_thenThrowsException() {
+    // given
+    Map<String, Object> emptyAttrs = Map.of();
+
+    // expect
+    assertThatThrownBy(() ->
+      factory.getOAuth2UserInfo("facebook", emptyAttrs)
+    )
+      .isInstanceOf(UnsupportedOperationException.class)
+      .hasMessageContaining("지원하지 않는 로그인 방식");
+  }
+}

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -13,6 +13,18 @@ spring:
             client-secret: GOOGLE_CLIENT_SECRET
             scope: openid, profile, email # openid 추가시 OIDC 플로우
             redirect-uri: "http://localhost:8080/login/oauth2/code/google"
+          kakao:
+            client-id: ${KAKAO_CLIENT_ID}
+            scope: profile_nickname, profile_image, account_email
+            authorization-grant-type: authorization_code
+            redirect-uri: "http://localhost:8080/login/oauth2/code/kakao"
+            provider: kakao
+        provider:
+          kakao:
+            authorization-uri: https://kauth.kakao.com/oauth/authorize
+            token-uri: https://kauth.kakao.com/oauth/token
+            user-info-uri: https://kapi.kakao.com/v2/user/me
+            user-name-attribute: id
 
   datasource:
     url: jdbc:h2:file:./build/h2db/testdb;INIT=CREATE SCHEMA IF NOT EXISTS moongch

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -13,6 +13,11 @@ spring:
             client-secret: GOOGLE_CLIENT_SECRET
             scope: openid, profile, email # openid 추가시 OIDC 플로우
             redirect-uri: "http://localhost:8080/login/oauth2/code/google"
+          github:
+            client-id: ${GITHUB_CLIENT_ID}
+            client-secret: ${GITHUB_CLIENT_SECRET}
+            scope: read:user, user:email
+            redirect-uri: "http://localhost:8080/login/oauth2/code/github"
           kakao:
             client-id: ${KAKAO_CLIENT_ID}
             scope: profile_nickname, profile_image, account_email


### PR DESCRIPTION
# CodeRabbit 요약

## 새로운 기능
- 기존 Google 외에도 GitHub와 Kakao를 OAuth2 로그인 제공자로 추가 지원
- GitHub OAuth2 로그인 시 주요 및 인증된 이메일 검색 기능 개선
- Google, GitHub, Kakao 로그인에 대한 사용자 정보 파싱 표준화

## 설정
- GitHub 및 Kakao OAuth2 제공자 정보를 포함하도록 개발 및 테스트 환경 설정 업데이트
- 개발을 위한 로깅 설정 향상

## 테스트
- OAuth2 사용자 정보 파싱 및 팩토리 로직에 대한 포괄적인 테스트 도입
- 로그아웃 동작 및 쿠키 처리를 확인하기 위한 컨트롤러 테스트 추가

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for OAuth2 login with GitHub and Kakao, alongside Google.
  - Enhanced OAuth2 user info parsing for Google, GitHub, and Kakao providers.
  - Introduced standardized handling of OAuth2 user information across providers.
  - Added a configuration for REST client usage within the application.

- **Bug Fixes**
  - Improved handling of user email retrieval for GitHub OAuth2 login.

- **Chores**
  - Updated application configuration to support additional OAuth2 providers and improved logging.
  - Refined GitHub Actions workflow triggers to exclude the "reopened" event.

- **Tests**
  - Added tests for OAuth2 user info parsing and factory logic.
  - Added controller tests for logout functionality.

- **Style**
  - Improved code formatting and consistency across several files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->